### PR TITLE
Support for large objects

### DIFF
--- a/syncS3blobstore.ini
+++ b/syncS3blobstore.ini
@@ -1,0 +1,60 @@
+[main]
+# debug > 0 spits out tons of debugging output
+debug=0
+# number of concurrent copy threads
+nthreads=4
+# mode to specify format of ids (default mode ws)
+mode=blobstore
+# mongo creds for source db
+mongo_host=localhost
+mongo_database = blobstore
+mongo_user = blobstore
+mongo_pwd = BLAH
+# mongo collection to query (usually s3_objects in ws mode, nodes in blobstore mode)
+mongo_collection=nodes
+# key field in collection (usually key in ws mode, id in blobstore mode)
+mongo_keyfield=id
+# datestamp for beginning date to start with
+# (defaults to 'now', rewritten to 'now' at the end of script)
+datefile=blobstoresync.last
+# log successful copied objects (also used to skip copying next run)
+logfile=blobstoresync.log
+# objects that failed to copy (for whatever reason)
+# this file is first read, then emptied, when the script is run
+retryfile=blobstoresync.retry
+# remove log before starting copy
+resetlog=0
+# path to mc minio client
+mcpath=/opt/mc/mc
+# for large files, where to download tmp files for mc to upload
+tmpdir=/path/to/mc/download/dir
+# larger than this will download to tmpdir and use mc to upload
+# smaller than this uses put_object which reads entire object into memory
+# nthreads*sizelimit should not exceed available RAM
+sizelimit=5000000000
+
+[source]
+# source S3 instance (currently only mc client uses)
+# endpoints use .mc/config.json labels
+endpoint = sources3
+bucket = blobstore
+# destination S3 config used by boto (to test whether target object already exists)
+url = https://storage.googleapis.com
+accessKey = BLAH
+secretKey = BLAH
+region = us-central-1
+# whether remote uses self-signed cert
+insecure=0
+
+[destination]
+# destination S3 instance
+# endpoints use .mc/config.json labels
+endpoint = dests3
+bucket = blobstore
+# destination S3 config used by boto (to test whether target object already exists)
+url = https://storage.googleapis.com
+accessKey = BLAH
+secretKey = BLAH
+region = us-central-1
+# whether remote uses self-signed cert
+insecure=0

--- a/syncS3blobstore.ini
+++ b/syncS3blobstore.ini
@@ -35,8 +35,6 @@ sizelimit=5000000000
 
 [source]
 # source S3 instance (currently only mc client uses)
-# endpoints use .mc/config.json labels
-endpoint = sources3
 bucket = blobstore
 # destination S3 config used by boto (to test whether target object already exists)
 url = https://storage.googleapis.com
@@ -48,8 +46,8 @@ insecure=0
 
 [destination]
 # destination S3 instance
-# endpoints use .mc/config.json labels
-endpoint = dests3
+# mcendpoint uses .mc/config.json labels
+mcendpoint = dests3
 bucket = blobstore
 # destination S3 config used by boto (to test whether target object already exists)
 url = https://storage.googleapis.com

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -130,7 +130,7 @@ def syncnode(id):
     return 0
 
   if (debug):
-    pprint ("looking for %s at source %s" % (id,conf['source']['url']) , stream=sys.stderr)
+    pprint ("looking for %s at source %s" % (objectPath,conf['source']['url']) , stream=sys.stderr)
 
   try:
     sourceObject = sourceS3.get_object(

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -177,7 +177,7 @@ def syncnode(id):
       pprint(mcCommand)
     # result = call(mcCommand)
 ## if mc succeeds, remove file from tmpdir
-    os.unlink (localfile)
+#    os.unlink (localfile)
 
     return 1
 

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -264,9 +264,9 @@ if __name__ == '__main__':
     )
 #        multipart_threshold=99999999999,
   transferConfig=boto3.s3.transfer.TransferConfig(
-        multipart_threshold=8388608,
-        max_concurrency=10,
-        num_download_attempts=10,
+        multipart_threshold=67108864,
+        max_concurrency=1,
+        num_download_attempts=1,
     )
 
   pprint ('start = %s'%(start) , stream=sys.stderr)

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -175,12 +175,12 @@ def syncnode(id):
 #      Config=transferConfig
 #    )
 
-   destResult = destS3.put_object(
-     Bucket=conf['destination']['bucket'],
-     Key=objectPath,
-     Body=sourceObject['Body'].read(),
-     Metadata=sourceObject['Metadata']
-   )
+    destResult = destS3.put_object(
+      Bucket=conf['destination']['bucket'],
+      Key=objectPath,
+      Body=sourceObject['Body'].read(),
+      Metadata=sourceObject['Metadata']
+    )
     writelog(conf['main']['logfile'],id)
     result = 0
   except botocore.exceptions.ClientError as e:

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -226,12 +226,12 @@ if __name__ == '__main__':
 
   if int(conf['source']['insecure']) == 1:
     sslVerifySource = False
-    import botocore.vendored.requests.packages.urllib3 as urllib3
-    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+#    import botocore.vendored.requests.packages.urllib3 as urllib3
+#    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
   if int(conf['destination']['insecure']) == 1:
     sslVerifyDest = False
-    import botocore.vendored.requests.packages.urllib3 as urllib3
-    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+#    import botocore.vendored.requests.packages.urllib3 as urllib3
+#    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
   readlog(conf['main']['logfile'],done)
   readlog(conf['main']['retryfile'],retry)

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -177,7 +177,7 @@ def syncnode(id):
       pprint(mcCommand)
     # result = call(mcCommand)
 ## if mc succeeds, remove file from tmpdir
-    os.unlink (localpath)
+    os.unlink (localfile)
 
     return 1
 

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -167,20 +167,20 @@ def syncnode(id):
 #  return 0
 
   try:
-    destResult = destS3.upload_fileobj(
-      sourceObject['Body'],
-      conf['destination']['bucket'],
-      objectPath,
-      ExtraArgs={ 'Metadata': sourceObject['Metadata']},
-      Config=transferConfig
-    )
+#    destResult = destS3.upload_fileobj(
+#      sourceObject['Body'],
+#      conf['destination']['bucket'],
+#      objectPath,
+#      ExtraArgs={ 'Metadata': sourceObject['Metadata']},
+#      Config=transferConfig
+#    )
 
-#   destResult = destS3.put_object(
-#     Bucket=conf['destination']['bucket'],
-#     Key=objectPath,
-#     Body=sourceObject['Body'].read(),
-#     Metadata=sourceObject['Metadata']
-#   )
+   destResult = destS3.put_object(
+     Bucket=conf['destination']['bucket'],
+     Key=objectPath,
+     Body=sourceObject['Body'].read(),
+     Metadata=sourceObject['Metadata']
+   )
     writelog(conf['main']['logfile'],id)
     result = 0
   except botocore.exceptions.ClientError as e:
@@ -189,7 +189,7 @@ def syncnode(id):
     pprint("id %s failed to copy, writing to retry file"%(id) , stream=sys.stderr)
     writelog(conf['main']['retryfile'],id)
     result = 1
-    raise(e)
+#    raise(e)
    
   return result 
 

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -153,7 +153,7 @@ def syncnode(id):
   if (debug):
     pprint ("copying %s (size %d) to destination %s %s" % (id,sourceStat['ContentLength'],conf['destination']['url'],objectPath) , stream=sys.stderr)
 
-  if (int(sourceStat['ContentLength']) > conf['main']['sizelimit']):
+  if (int(sourceStat['ContentLength']) > int(conf['main']['sizelimit'])):
     pprint ("object %s is huge, size %d, falling back to mc" % (id,sourceStat['ContentLength']) )
 ##### put_object will read the entire body into memory, so for large files it is prohibitive
 ##### workaround to do:

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -129,6 +129,9 @@ def syncnode(id):
     writelog(conf['main']['logfile'],id)
     return 0
 
+  if (debug):
+    pprint ("looking for %s at source %s" % (id,conf['source']['url']) , stream=sys.stderr)
+
   try:
     sourceObject = sourceS3.get_object(
       Bucket=conf['source']['bucket'],

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -104,55 +104,67 @@ def syncnode(id):
       pprint ("%s found in log, skipping" % (id), stream=sys.stderr)
     return 0
 
-  spath="%s/%s/%s"%(conf['source']['endpoint'],conf['source']['bucket'],id)
-  dpath="%s/%s/%s"%(conf['destination']['endpoint'],conf['destination']['bucket'],id)
-  s3dpath=id
+  objectPath=id
   if (conf['main']['mode'] == 'blobstore'):
-    spath="%s/%s/%s/%s/%s/%s"%(conf['source']['endpoint'],conf['source']['bucket'],id[0:2],id[2:4],id[4:6],id)
-    dpath="%s/%s/%s/%s/%s/%s"%(conf['destination']['endpoint'],conf['destination']['bucket'],id[0:2],id[2:4],id[4:6],id)
-    s3dpath="%s/%s/%s/%s"%(id[0:2],id[2:4],id[4:6],id)
+    objectPath="%s/%s/%s/%s"%(id[0:2],id[2:4],id[4:6],id)
 
   if (debug):
-    pprint ("looking for %s at destination %s" % (id,s3dpath) , stream=sys.stderr)
+    pprint ("looking for %s at destination %s" % (id,objectPath) , stream=sys.stderr)
   deststat = dict()
   try:
-    deststat = targetS3.head_object(Bucket=conf['destination']['bucket'],Key=s3dpath)
-    if (debug):
-      pprint("deststat is %s" % deststat)
+    deststat = destS3.head_object(Bucket=conf['destination']['bucket'],Key=objectPath)
+#    if (debug):
+#      pprint("deststat is %s" % deststat)
   except botocore.exceptions.ClientError as e:
 # if 404 not found, need to put
     if ('404' in e.message):
       if (debug):
-        pprint("%s not found at destination %s"%(id, s3dpath) , stream=sys.stderr)
+        pprint("%s not found at destination %s"%(id, objectPath) , stream=sys.stderr)
     else:
 # otherwise, something bad happened, raise a real exception
       raise(e)
   if ('ETag' in deststat):
     if (debug):
-      pprint ("%s found at destination %s with ETag %s, skipping" % (id, s3dpath, deststat['ETag']), stream=sys.stderr)
+      pprint ("%s found at destination %s with ETag %s, skipping" % (id, objectPath, deststat['ETag']), stream=sys.stderr)
     writelog(conf['main']['logfile'],id)
     return 0
 
+  try:
+    sourceObject = sourceS3.get_object(
+      Bucket=conf['source']['bucket'],
+      Key=objectPath
+    )
+  except botocore.exceptions.ClientError as e:
+# if 404 not found, just skip, likely bad Shock node
+    if ('404' in e.message):
+      if (debug):
+        pprint("%s not found at source %s, skipping" % (id, conf['source']['url']) , stream=sys.stderr)
+      return 0
+    else:
+# otherwise, something bad happened, raise a real exception
+      raise(e)
+
   if (debug):
-    pprint ("copying %s to destination %s" % (id,dpath) , stream=sys.stderr)
-  # example from vadmin1:
-  # assumes `minio` and `prod-ws01` are defined endpoints in ~/.mc/config.json
-  # /opt/mc/mc cp minio/prod-ws/00/00/00/000000e7-0d44-494b-bd17-638f2a904329 prod-ws01.gcp/prod-ws01/00/00/00/000000e7-0d44-494b-bd17-638f2a904329
-  comm=(conf['main']['mcpath'],'--quiet','cp',spath,dpath)
-# use echo for testing
-  #comm=('echo',conf['main']['mcpath'],'--quiet','cp',spath,dpath)
-  if (conf['main'].getboolean('insecureminio') == True):
-      comm=(conf['main']['mcpath'],'--quiet','--insecure','cp',spath,dpath)
-      # use echo for testing
-      # comm=('echo',conf['main']['mcpath'],'--quiet','--insecure','cp',spath,dpath)
-  if (int(debug) > 4):
-    pprint ("command is '%s'" % comm, stream=sys.stderr)
-  result=call(comm)
-  if result==0:
+    pprint ("copying %s to destination %s %s" % (id,conf['destination']['url'],objectPath) , stream=sys.stderr)
+
+  return 0
+
+  try:
+    destResult = destS3.put_object(
+      Bucket=conf['destination']['bucket'],
+      Key=objectId,
+      Body=sourceObject['Body'].read(),
+      Metadata=sourceObject['Metadata']
+    )
     writelog(conf['main']['logfile'],id)
-  else:
+    result = 0
+  except botocore.exceptions.ClientError as e:
+    # not sure what to do here yet
+    pprint(e.message)
     pprint("id %s failed to copy, writing to retry file"%(id) , stream=sys.stderr)
     writelog(conf['main']['retryfile'],id)
+    result = 1
+#    raise(e)
    
   return result 
 
@@ -184,10 +196,15 @@ if __name__ == '__main__':
     start = datetime.datetime.strptime(args.startdate,"%Y-%m-%dT%H:%M:%S.%f")
   if (args.enddate):
     end = datetime.datetime.strptime(args.enddate,"%Y-%m-%dT%H:%M:%S.%f")
-  sslVerify = True
-#  if ('insecuredest' in conf['main'].keys() and conf['main']['insecuredest'] == 1):
-  if int(conf['main']['insecuredest']) == 1:
-    sslVerify = False
+  sslVerifySource = True
+  sslVerifyDest = True
+
+  if int(conf['source']['insecure']) == 1:
+    sslVerifySource = False
+    import botocore.vendored.requests.packages.urllib3 as urllib3
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+  if int(conf['destination']['insecure']) == 1:
+    sslVerifyDest = False
     import botocore.vendored.requests.packages.urllib3 as urllib3
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
@@ -198,16 +215,26 @@ if __name__ == '__main__':
     debug=1
 
   if debug:
-    pprint('sslVerify = ' + str(sslVerify), stream=sys.stderr)
+    pprint('sslVerifySource = %s , sslVerifyDest = %s' % (str(sslVerifySource),str(sslVerifyDest), stream=sys.stderr)
 
-  targetS3 = boto3.client(
+  sourceS3 = boto3.client(
+        's3',
+        endpoint_url=conf['source']['url'],
+        aws_access_key_id=conf['source']['accessKey'],
+        aws_secret_access_key=conf['source']['secretKey'],
+        region_name=conf['source']['region'],
+        config=bcfg.Config(s3={'addressing_style': 'path'}),
+	verify=sslVerifySource
+    )
+
+  destS3 = boto3.client(
         's3',
         endpoint_url=conf['destination']['url'],
         aws_access_key_id=conf['destination']['accessKey'],
         aws_secret_access_key=conf['destination']['secretKey'],
         region_name=conf['destination']['region'],
         config=bcfg.Config(s3={'addressing_style': 'path'}),
-	verify=sslVerify
+	verify=sslVerifyDest
     )
 
   pprint ('start = %s'%(start) , stream=sys.stderr)

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -155,7 +155,7 @@ def syncnode(id):
 #  if (int(sourceStat['ContentLength']) > 20000000000):
 # ~ 5gb
   if (int(sourceStat['ContentLength']) > 5000000000):
-    pprint ("object %s is huge, size %d, skipping" % (id,sourceStat['ContentLength']) )
+    pprint ("object %s is huge, size %d, falling back to mc" % (id,sourceStat['ContentLength']) )
 ##### put_object will read the entire body into memory, so for large files it is prohibitive
 ##### workaround to do:
 ## use download_file (or download_fileobj) to download to a tmp dir conf['main']['tmpdir']

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -140,8 +140,7 @@ def syncnode(id):
   except botocore.exceptions.ClientError as e:
 # if 404 not found, just skip, likely bad Shock node
     if ('404' in e.message):
-      if (debug):
-        pprint("%s not found at source %s, skipping" % (id, conf['source']['url']) , stream=sys.stderr)
+      pprint("%s not found at source %s, skipping" % (id, conf['source']['url']) , stream=sys.stderr)
       return 0
     else:
 # otherwise, something bad happened, raise a real exception

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -149,7 +149,7 @@ def syncnode(id):
   if (debug):
     pprint ("copying %s (size %d) to destination %s %s" % (id,sourceStat['ContentLength'],conf['destination']['url'],objectPath) , stream=sys.stderr)
   if (int(sourceStat['ContentLength']) > 20000000000):
-    pprint ("object %s is huge, size %d, skipping" % (id,sourceStat['ContentLength']) , stream=sys.stdout)
+    pprint ("object %s is huge, size %d, skipping" % (id,sourceStat['ContentLength']) )
     return 1
 
   try:

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -119,7 +119,7 @@ def syncnode(id):
   except botocore.exceptions.ClientError as e:
 # if 404 not found, need to put
 #    pprint(e)
-    if ('404' in e):
+    if ('404' in str(e)):
       if (debug):
         pprint("%s not found at destination %s"%(id, objectPath) , stream=sys.stderr)
     else:
@@ -141,7 +141,7 @@ def syncnode(id):
     )
   except botocore.exceptions.ClientError as e:
 # if 404 not found, just skip, likely bad Shock node
-    if ('404' in e):
+    if ('404' in str(e)):
       pprint("%s not found at source %s, skipping" % (id, conf['source']['url']) , stream=sys.stderr)
       return 0
     else:
@@ -213,7 +213,7 @@ def syncnode(id):
     result = 0
   except botocore.exceptions.ClientError as e:
     # not sure what to do here yet
-    pprint(e, stream=sys.stderr)
+    pprint(str(e), stream=sys.stderr)
     pprint("id %s failed to copy, writing to retry file"%(id) , stream=sys.stderr)
     writelog(conf['main']['retryfile'],id)
     result = 1

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -167,11 +167,12 @@ def syncnode(id):
 #  return 0
 
   try:
-    destResult = destTransferClient.upload_fileobj(
+    destResult = destS3.upload_fileobj(
       sourceObject['Body'],
       conf['destination']['bucket'],
       objectPath,
-      ExtraArgs={ 'Metadata': sourceObject['Metadata'] }
+      ExtraArgs={ 'Metadata': sourceObject['Metadata']},
+      Config=transferConfig
     )
 
 #   destResult = destS3.put_object(
@@ -265,7 +266,6 @@ if __name__ == '__main__':
         max_concurrency=10,
         num_download_attempts=10,
     )
-  destTransferClient = boto3.s3.transfer.S3Transfer(destS3, transferConfig)
 
   pprint ('start = %s'%(start) , stream=sys.stderr)
   pprint ('end = %s'%(end) , stream=sys.stderr)

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -184,7 +184,7 @@ def syncnode(id):
     result = 0
   except botocore.exceptions.ClientError as e:
     # not sure what to do here yet
-    pprint(e.message)
+    pprint(e.message, stream=sys.stderr)
     pprint("id %s failed to copy, writing to retry file"%(id) , stream=sys.stderr)
     writelog(conf['main']['retryfile'],id)
     result = 1

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -133,7 +133,7 @@ def syncnode(id):
     pprint ("looking for %s at source %s" % (objectPath,conf['source']['url']) , stream=sys.stderr)
 
   try:
-    sourceObject = sourceS3.get_object(
+    sourceObject = sourceS3.head_object(
       Bucket=conf['source']['bucket'],
       Key=objectPath
     )

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -110,9 +110,9 @@ def syncnode(id):
 
   if (debug):
     pprint ("looking for %s at destination %s" % (id,objectPath) , stream=sys.stderr)
-  deststat = dict()
+  destStat = dict()
   try:
-    deststat = destS3.head_object(Bucket=conf['destination']['bucket'],Key=objectPath)
+    destStat = destS3.head_object(Bucket=conf['destination']['bucket'],Key=objectPath)
 #    if (debug):
 #      pprint("deststat is %s" % deststat)
   except botocore.exceptions.ClientError as e:
@@ -123,9 +123,9 @@ def syncnode(id):
     else:
 # otherwise, something bad happened, raise a real exception
       raise(e)
-  if ('ETag' in deststat):
+  if ('ETag' in destStat):
     if (debug):
-      pprint ("%s found at destination %s with ETag %s, skipping" % (id, objectPath, deststat['ETag']), stream=sys.stderr)
+      pprint ("%s found at destination %s with ETag %s, skipping" % (id, objectPath, destStat['ETag']), stream=sys.stderr)
     writelog(conf['main']['logfile'],id)
     return 0
 
@@ -133,12 +133,10 @@ def syncnode(id):
     pprint ("looking for %s at source %s" % (objectPath,conf['source']['url']) , stream=sys.stderr)
 
   try:
-    sourceObject = sourceS3.head_object(
+    sourceStat = sourceS3.head_object(
       Bucket=conf['source']['bucket'],
       Key=objectPath
     )
-    if (debug):
-      pprint(sourceObject)
   except botocore.exceptions.ClientError as e:
 # if 404 not found, just skip, likely bad Shock node
     if ('404' in e.message):
@@ -151,6 +149,14 @@ def syncnode(id):
 
   if (debug):
     pprint ("copying %s to destination %s %s" % (id,conf['destination']['url'],objectPath) , stream=sys.stderr)
+
+  try:
+    sourceObject = sourceS3.get_object(
+      Bucket=conf['source']['bucket'],
+      Key=objectPath
+    )
+  except botocore.exceptions.ClientError as e:
+      raise(e)
 
   return 0
 

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -148,7 +148,10 @@ def syncnode(id):
 
   if (debug):
     pprint ("copying %s (size %d) to destination %s %s" % (id,sourceStat['ContentLength'],conf['destination']['url'],objectPath) , stream=sys.stderr)
-  if (int(sourceStat['ContentLength']) > 20000000000):
+# ~ 20gb
+#  if (int(sourceStat['ContentLength']) > 20000000000):
+# ~ 5gb
+  if (int(sourceStat['ContentLength']) > 5000000000):
     pprint ("object %s is huge, size %d, skipping" % (id,sourceStat['ContentLength']) )
     return 1
 

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -215,7 +215,7 @@ if __name__ == '__main__':
     debug=1
 
   if debug:
-    pprint('sslVerifySource = %s , sslVerifyDest = %s' % (str(sslVerifySource),str(sslVerifyDest), stream=sys.stderr)
+    pprint('sslVerifySource = %s , sslVerifyDest = %s' % (str(sslVerifySource),str(sslVerifyDest)), stream=sys.stderr)
 
   sourceS3 = boto3.client(
         's3',

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -263,7 +263,7 @@ if __name__ == '__main__':
     )
 #        multipart_threshold=99999999999,
   transferConfig=boto3.s3.transfer.TransferConfig(
-        multipart_threshold=9999999999,
+        multipart_threshold=8388608,
         max_concurrency=10,
         num_download_attempts=10,
     )

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -261,8 +261,9 @@ if __name__ == '__main__':
         config=bcfg.Config(s3={'addressing_style': 'path'}),
 	verify=sslVerifyDest
     )
+#        multipart_threshold=99999999999,
   transferConfig=boto3.s3.transfer.TransferConfig(
-        multipart_threshold=99999999999,
+        multipart_threshold=9999999999,
         max_concurrency=10,
         num_download_attempts=10,
     )

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -189,7 +189,7 @@ def syncnode(id):
     pprint("id %s failed to copy, writing to retry file"%(id) , stream=sys.stderr)
     writelog(conf['main']['retryfile'],id)
     result = 1
-#    raise(e)
+    raise(e)
    
   return result 
 

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -158,7 +158,8 @@ def syncnode(id):
   except botocore.exceptions.ClientError as e:
       raise(e)
 
-  return 0
+# leave early when debugging
+#  return 0
 
   try:
     destResult = destS3.put_object(

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -5,12 +5,13 @@ This is a beta version modifying our existing synctool.py for Shock sync to do
 S3 to S3 sync instead.
 
 To do:
+  * support for not reading entire object into memory before copying (in progress)
+  * replace calling mc binary with making native python calls? (in progress)
+    * currently mc stdout goes to the script stdout, which is a bit messy
+  * better documentation of config file (see syncS3ws.ini in this repo)
   * better and more organized logging (mostly done)
   * add support for start date on command line?
   * make it possible to use same config file for ws/blobstore?
-  * replace calling mc binary with making native python calls?
-    * currently mc stdout goes to the script stdout, which is a bit messy
-  * better documentation of config file (see syncS3ws.ini in this repo, mostly done)
   * support ws/blobstore mode (done)
   * check for target object and skip if exists (done)
     * verify MD5 too?
@@ -31,6 +32,7 @@ import argparse
 import boto3
 import botocore
 import botocore.config as bcfg
+import smart_open
 
 done=dict()
 retry=dict()

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -47,7 +47,7 @@ def writelog(filename,node):
 
 def readlog(filename,list):
   if not os.path.exists(filename):
-    print "Warning: %s doesn't exist"%(filename)
+    pprint ("Warning: %s doesn't exist" % filename)
     return
   with open(filename,"r") as f:
     for id in f:

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -118,8 +118,8 @@ def syncnode(id):
 #      pprint("deststat is %s" % deststat)
   except botocore.exceptions.ClientError as e:
 # if 404 not found, need to put
-    pprint(e)
-    if ('404' in e.message):
+#    pprint(e)
+    if ('404' in e):
       if (debug):
         pprint("%s not found at destination %s"%(id, objectPath) , stream=sys.stderr)
     else:
@@ -141,7 +141,7 @@ def syncnode(id):
     )
   except botocore.exceptions.ClientError as e:
 # if 404 not found, just skip, likely bad Shock node
-    if ('404' in e.message):
+    if ('404' in e):
       pprint("%s not found at source %s, skipping" % (id, conf['source']['url']) , stream=sys.stderr)
       return 0
     else:
@@ -213,7 +213,7 @@ def syncnode(id):
     result = 0
   except botocore.exceptions.ClientError as e:
     # not sure what to do here yet
-    pprint(e.message, stream=sys.stderr)
+    pprint(e, stream=sys.stderr)
     pprint("id %s failed to copy, writing to retry file"%(id) , stream=sys.stderr)
     writelog(conf['main']['retryfile'],id)
     result = 1

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -137,6 +137,8 @@ def syncnode(id):
       Bucket=conf['source']['bucket'],
       Key=objectPath
     )
+    if (debug):
+      pprint(sourceObject)
   except botocore.exceptions.ClientError as e:
 # if 404 not found, just skip, likely bad Shock node
     if ('404' in e.message):

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -167,12 +167,19 @@ def syncnode(id):
 #  return 0
 
   try:
-    destResult = destS3.put_object(
-      Bucket=conf['destination']['bucket'],
-      Key=objectPath,
-      Body=sourceObject['Body'].read(),
-      Metadata=sourceObject['Metadata']
+    destResult = destS3.upload_fileobj(
+      sourceObject['Body'],
+      conf['destination']['bucket'],
+      objectPath,
+      ExtraArgs={ 'Metadata': sourceObject['Metadata'] }
     )
+
+#   destResult = destS3.put_object(
+#     Bucket=conf['destination']['bucket'],
+#     Key=objectPath,
+#     Body=sourceObject['Body'].read(),
+#     Metadata=sourceObject['Metadata']
+#   )
     writelog(conf['main']['logfile'],id)
     result = 0
   except botocore.exceptions.ClientError as e:

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -118,6 +118,7 @@ def syncnode(id):
 #      pprint("deststat is %s" % deststat)
   except botocore.exceptions.ClientError as e:
 # if 404 not found, need to put
+    pprint(e)
     if ('404' in e.message):
       if (debug):
         pprint("%s not found at destination %s"%(id, objectPath) , stream=sys.stderr)

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -174,7 +174,7 @@ def syncnode(id):
 ### optional: add filename metadata if it exists
     mcCommand=(conf['main']['mcpath'],'--quiet','cp',localfile,destPath)
     if (debug):
-      pprint(mcCommand)
+      pprint(mcCommand, stream=sys.stderr)
     # result = call(mcCommand)
 ## if mc succeeds, remove file from tmpdir
 #    os.unlink (localfile)

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -264,7 +264,7 @@ if __name__ == '__main__':
     )
 #        multipart_threshold=99999999999,
   transferConfig=boto3.s3.transfer.TransferConfig(
-        multipart_threshold=67108864,
+        multipart_threshold=4294967296,
         max_concurrency=1,
         num_download_attempts=1,
     )

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -164,7 +164,8 @@ def syncnode(id):
     localfile = conf['main']['tmpdir'] + '/' + id
     if (debug):
       pprint ("downloading %s to %s" % (objectPath,localfile) , stream=sys.stderr)
-#    sourceDownloadResult = sourceS3.download_file(conf['source']['bucket'],objectPath,localfile)
+    # need to check this result
+    sourceDownloadResult = sourceS3.download_file(conf['source']['bucket'],objectPath,localfile)
 ## generate destPath as an mc path
     destPath="%s/%s/%s"%(conf['destination']['mcendpoint'],conf['destination']['bucket'],id)
     if (conf['main']['mode'] == 'blobstore'):
@@ -175,10 +176,12 @@ def syncnode(id):
     mcCommand=(conf['main']['mcpath'],'--quiet','cp',localfile,destPath)
     if (debug):
       pprint(mcCommand, stream=sys.stderr)
-    # result = call(mcCommand)
-## if mc succeeds, remove file from tmpdir
-#    os.unlink (localfile)
+    result = call(mcCommand)
+## if mc succeeds, remove file from tmpdir, write log, and return 0
+    if (result == 0):
+      os.unlink (localfile)
 
+## for debugging: don't write log and return 1
     return 1
 
 # this doesn't work with google S3
@@ -201,7 +204,6 @@ def syncnode(id):
 # leave early when debugging
 #  return 0
 
-# future: maybe replace this with smart_open call too?
   try:
     destResult = destS3.put_object(
       Bucket=conf['destination']['bucket'],

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!env python3
 
 '''
 This is a beta version modifying our existing synctool.py for Shock sync to do

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -148,6 +148,9 @@ def syncnode(id):
 
   if (debug):
     pprint ("copying %s (size %d) to destination %s %s" % (id,sourceStat['ContentLength'],conf['destination']['url'],objectPath) , stream=sys.stderr)
+  if (int(sourceStat['ContentLength']) > 20000000000):
+    pprint ("object %s is huge, size %d, skipping" % (id,sourceStat['ContentLength']) , stream=sys.stdout)
+    return 1
 
   try:
     sourceObject = sourceS3.get_object(

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -164,7 +164,7 @@ def syncnode(id):
   try:
     destResult = destS3.put_object(
       Bucket=conf['destination']['bucket'],
-      Key=objectId,
+      Key=objectPath,
       Body=sourceObject['Body'].read(),
       Metadata=sourceObject['Metadata']
     )

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -264,7 +264,7 @@ if __name__ == '__main__':
     )
 #        multipart_threshold=99999999999,
   transferConfig=boto3.s3.transfer.TransferConfig(
-        multipart_threshold=4294967296,
+        multipart_threshold=67108864,
         max_concurrency=1,
         num_download_attempts=1,
     )

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -167,7 +167,7 @@ def syncnode(id):
 #  return 0
 
   try:
-    destResult = destS3.upload_fileobj(
+    destResult = destTransferClient.upload_fileobj(
       sourceObject['Body'],
       conf['destination']['bucket'],
       objectPath,
@@ -260,6 +260,12 @@ if __name__ == '__main__':
         config=bcfg.Config(s3={'addressing_style': 'path'}),
 	verify=sslVerifyDest
     )
+  transferConfig=boto3.s3.transfer.TransferConfig(
+        multipart_threshold=9999999999999999,
+        max_concurrency=10,
+        num_download_attempts=10,
+    )
+  destTransferClient = boto3.s3.transfer.S3Transfer(destS3, transferConfig)
 
   pprint ('start = %s'%(start) , stream=sys.stderr)
   pprint ('end = %s'%(end) , stream=sys.stderr)

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -262,7 +262,7 @@ if __name__ == '__main__':
 	verify=sslVerifyDest
     )
   transferConfig=boto3.s3.transfer.TransferConfig(
-        multipart_threshold=9999999999999999,
+        multipart_threshold=99999999999,
         max_concurrency=10,
         num_download_attempts=10,
     )

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -6,9 +6,10 @@ S3 to S3 sync instead.
 
 To do:
   * support for not reading entire object into memory before copying (in progress)
-  * replace calling mc binary with making native python calls? (in progress)
+    * put_object reads entire body into memory so not suitable for large files
+  * replace calling mc binary with making native python calls for not-too-large files
     * currently mc stdout goes to the script stdout, which is a bit messy
-  * better documentation of config file (see syncS3ws.ini in this repo)
+  * better documentation of config file (see syncS3ws.ini in this repo) (in progress)
   * better and more organized logging (mostly done)
   * add support for start date on command line?
   * make it possible to use same config file for ws/blobstore?

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -177,7 +177,7 @@ def syncnode(id):
       pprint(mcCommand)
     # result = call(mcCommand)
 ## if mc succeeds, remove file from tmpdir
-    unlink (localpath)
+    os.unlink (localpath)
 
     return 1
 

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -163,7 +163,7 @@ def syncnode(id):
     # so no risk of putting too many files in one dir
     localfile = conf['main']['tmpdir'] + '/' + id
     if (debug):
-      pprint ("downloading %s to %s" % objectPath,localfile)
+      pprint ("downloading %s to %s" % (objectPath,localfile) , stream=sys.stderr)
 #    sourceDownloadResult = sourceS3.download_file(conf['source']['bucket'],objectPath,localfile)
 ## generate destPath as an mc path
     destPath="%s/%s/%s"%(conf['destination']['mcendpoint'],conf['destination']['bucket'],id)

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -226,12 +226,13 @@ if __name__ == '__main__':
 
   if int(conf['source']['insecure']) == 1:
     sslVerifySource = False
-#    import botocore.vendored.requests.packages.urllib3 as urllib3
-#    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+# these don't work right with python 3
+    import botocore.vendored.requests.packages.urllib3 as urllib3
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
   if int(conf['destination']['insecure']) == 1:
     sslVerifyDest = False
-#    import botocore.vendored.requests.packages.urllib3 as urllib3
-#    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    import botocore.vendored.requests.packages.urllib3 as urllib3
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
   readlog(conf['main']['logfile'],done)
   readlog(conf['main']['retryfile'],retry)

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -5,6 +5,7 @@ This is a beta version modifying our existing synctool.py for Shock sync to do
 S3 to S3 sync instead.
 
 To do:
+  * better defaults if key not in config file
   * support for not reading entire object into memory before copying (in progress)
     * put_object reads entire body into memory so not suitable for large files
   * replace calling mc binary with making native python calls for not-too-large files

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -155,7 +155,32 @@ def syncnode(id):
 # ~ 5gb
   if (int(sourceStat['ContentLength']) > 5000000000):
     pprint ("object %s is huge, size %d, skipping" % (id,sourceStat['ContentLength']) )
+##### put_object will read the entire body into memory, so for large files it is prohibitive
+##### workaround to do:
+## use download_file (or download_fileobj) to download to a tmp dir conf['main']['tmpdir']
+    # don't bother with hash dirs, we're just going to remove later
+    # so no risk of putting too many files in one dir
+    localfile = conf['main']['tmpdir'] + '/' + id
+    if (debug):
+      pprint ("downloading %s to %s" % objectPath,localfile)
+#    sourceDownloadResult = sourceS3.download_file(conf['source']['bucket'],objectPath,localfile)
+## generate destPath as an mc path
+    destPath="%s/%s/%s"%(conf['destination']['mcendpoint'],conf['destination']['bucket'],id)
+    if (conf['main']['mode'] == 'blobstore'):
+      destPath="%s/%s/%s/%s/%s/%s"%(conf['destination']['mcendpoint'],conf['destination']['bucket'],id[0:2],id[2:4]
+,id[4:6],id)
+## use comm=(conf['main']['mcpath'],'--quiet','cp',localfile,destPath) to upload
+### optional: add filename metadata if it exists
+    mcCommand=(conf['main']['mcpath'],'--quiet','cp',localfile,destPath)
+    if (debug):
+      pprint(mcCommand)
+    # result = call(mcCommand)
+## if mc succeeds, remove file from tmpdir
+    unlink (localpath)
+
     return 1
+
+# this doesn't work with google S3
 #    destResult = destS3.upload_fileobj(
 #      sourceObject,
 #      conf['destination']['bucket'],

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -147,7 +147,7 @@ def syncnode(id):
       raise(e)
 
   if (debug):
-    pprint ("copying %s to destination %s %s" % (id,conf['destination']['url'],objectPath) , stream=sys.stderr)
+    pprint ("copying %s (size %d) to destination %s %s" % (id,sourceStat['ContentLength'],conf['destination']['url'],objectPath) , stream=sys.stderr)
 
   try:
     sourceObject = sourceS3.get_object(

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -226,13 +226,14 @@ if __name__ == '__main__':
 
   if int(conf['source']['insecure']) == 1:
     sslVerifySource = False
-# these don't work right with python 3
-    import botocore.vendored.requests.packages.urllib3 as urllib3
+    import urllib3
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    urllib3.disable_warnings(botocore.vendored.requests.packages.urllib3.exceptions.InsecureRequestWarning) 
   if int(conf['destination']['insecure']) == 1:
     sslVerifyDest = False
-    import botocore.vendored.requests.packages.urllib3 as urllib3
+    import urllib3
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    urllib3.disable_warnings(botocore.vendored.requests.packages.urllib3.exceptions.InsecureRequestWarning) 
 
   readlog(conf['main']['logfile'],done)
   readlog(conf['main']['retryfile'],retry)

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -5,6 +5,7 @@ This is a beta version modifying our existing synctool.py for Shock sync to do
 S3 to S3 sync instead.
 
 To do:
+  * --dry-run flag to report objects and sizes that would be copied
   * better defaults if key not in config file
   * support for not reading entire object into memory before copying (in progress)
     * put_object reads entire body into memory so not suitable for large files

--- a/syncS3ws.ini
+++ b/syncS3ws.ini
@@ -26,22 +26,32 @@ retryfile=wssync.retry
 resetlog=0
 # path to mc minio client
 mcpath=/opt/mc/mc
-# required if either minio instance uses a self-signed cert
-insecureminio=True
+# tmp dir used if a file exceeds sizelimit (rare for ws objects)
+tmpdir=/mnt/backups/syncS3toS3
+# above this limit will download to tmpdir and use mc to upload
+sizelimit=5000000000
+
 
 [source]
-# source S3 instance (currently only mc client uses)
-# endpoints use .mc/config.json labels
-endpoint = sources3
-bucket = ws
-
-[destination]
-# destination S3 instance
-# endpoints use .mc/config.json labels
-endpoint = dests3
+# source S3 instance
 bucket = ws
 # destination S3 config used by boto (to test whether target object already exists)
 url = https://storage.googleapis.com
 accessKey = BLAH
 secretKey = BLAH
 region = us-central-1
+# whether remote uses self-signed cert
+insecure=0
+
+[destination]
+# destination S3 instance
+# mcendpoint uses .mc/config.json labels
+mcendpoint = dests3
+bucket = ws
+# destination S3 config used by boto (to test whether target object already exists)
+url = https://storage.googleapis.com
+accessKey = BLAH
+secretKey = BLAH
+region = us-central-1
+# whether remote uses self-signed cert
+insecure=0


### PR DESCRIPTION
put_object reads the entire source body into memory before copying to the destination, which is problematic for blobstore objects that are large.  Instead of copying directly from the source to the destination, copy large objects to a tmp dir, then use `mc` to copy up.