### PR TITLE
add metadata in ASCII

### DIFF
--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -327,6 +327,9 @@ if __name__ == '__main__':
 
   initlog(conf['main']['retryfile'])
 
+# creating this list here means everything fed into pool.map needs to be synced
+# should avoid potential problem where one subprocess runs out of objects to sync
+# while other subprocesses have a lot of objects to sync
   syncObjectList = list()
   for objectId in objectList:
     if objectId in done:

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -35,6 +35,7 @@ import argparse
 import boto3
 import botocore
 import botocore.config as bcfg
+import unicodedata
 
 done=dict()
 retry=dict()
@@ -207,11 +208,14 @@ def syncnode(id):
 #  return 0
 
   try:
+    metadata = sourceObject['Metadata']
+# normalize filename to ASCII
+    metadata['filename'] = unicodedata.normalize('NFKD', sourceObject['Metadata']['filename']).encode('ascii', 'ignore').decode()
     destResult = destS3.put_object(
       Bucket=conf['destination']['bucket'],
       Key=objectPath,
       Body=sourceObject['Body'].read(),
-      Metadata=sourceObject['Metadata']
+      Metadata=metadata
     )
     writelog(conf['main']['logfile'],id)
     result = 0

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -103,6 +103,8 @@ def getObjects(start, end):
 
 def syncnode(id):
 
+  # this if *should* now be redundant, since done is checked before pool.map in main()
+  # (but can't hurt and should be very fast)
   if id in done:
     #writelog(conf['logfile'],id)
     if (debug):

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -222,6 +222,13 @@ def syncnode(id):
     writelog(conf['main']['retryfile'],id)
     result = 1
 #    raise(e)
+  except botocore.exceptions.ParamValidationError as e:
+    # not sure what to do here yet
+    pprint(str(e), stream=sys.stderr)
+    pprint("id %s failed to copy, writing to retry file"%(id) , stream=sys.stderr)
+    writelog(conf['main']['retryfile'],id)
+    result = 1
+#    raise(e)
    
   return result 
 

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -210,7 +210,8 @@ def syncnode(id):
   try:
     metadata = sourceObject['Metadata']
 # normalize filename to ASCII
-    metadata['filename'] = unicodedata.normalize('NFKD', sourceObject['Metadata']['filename']).encode('ascii', 'ignore').decode()
+    if 'filename' in metadata.keys():
+      metadata['filename'] = unicodedata.normalize('NFKD', sourceObject['Metadata']['filename']).encode('ascii', 'ignore').decode()
     destResult = destS3.put_object(
       Bucket=conf['destination']['bucket'],
       Key=objectPath,

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -330,7 +330,7 @@ if __name__ == '__main__':
     if objectId in done:
     #writelog(conf['logfile'],id)
       if (debug):
-        pprint ("%s found in log, not adding to sync list" % (id), stream=sys.stderr)
+        pprint ("%s found in log, not adding to sync list" % (objectId), stream=sys.stderr)
     else:
       syncObjectList.append(objectId)
 

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -325,8 +325,17 @@ if __name__ == '__main__':
 
   initlog(conf['main']['retryfile'])
 
+  syncObjectList = list()
+  for objectId in objectList:
+    if objectId in done:
+    #writelog(conf['logfile'],id)
+      if (debug):
+        pprint ("%s found in log, not adding to sync list" % (id), stream=sys.stderr)
+    else:
+      syncObjectList.append(objectId)
+
   pool = Pool(processes=int(conf['main']['nthreads']))
-  results=pool.map(syncnode, objectList)
+  results=pool.map(syncnode, syncObjectList)
   failed=0
   for result in results:
     if result:

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -215,14 +215,9 @@ def syncnode(id):
     )
     writelog(conf['main']['logfile'],id)
     result = 0
-  except botocore.exceptions.ClientError as e:
-    # not sure what to do here yet
-    pprint(str(e), stream=sys.stderr)
-    pprint("id %s failed to copy, writing to retry file"%(id) , stream=sys.stderr)
-    writelog(conf['main']['retryfile'],id)
-    result = 1
-#    raise(e)
-  except botocore.exceptions.ParamValidationError as e:
+#  except botocore.exceptions.ClientError as e:
+# aggressively capture all exceptions here so the object id gets logged to retry file
+  except Exception as e:
     # not sure what to do here yet
     pprint(str(e), stream=sys.stderr)
     pprint("id %s failed to copy, writing to retry file"%(id) , stream=sys.stderr)


### PR DESCRIPTION
If an object's metadata includes non-ASCII, put_object may throw a ParamValidationError exception, which is not currently caught.  This means the script dies immediately and doesn't log failed object ids to the retry file, so we don't know there's a problem unless we inspect stderr.

We also need to convert the non-ASCII metadata to ASCII so we can save it to Google S3.  (Minio seems to support non-ASCII characters but I think it's fine to convert anyway and not rely on that feature.  Blobstore doesn't verify the S3 object metadata against mongodb so it's fine if it doesn't match.)