### PR TITLE
--disable-multipart option

### DIFF
--- a/syncS3blobstore.ini
+++ b/syncS3blobstore.ini
@@ -36,6 +36,9 @@ tmpdir=/path/to/mc/download/dir
 sizelimit=5000000000
 # use nondefault storage class if desired
 storageclass=REDUCED_REDUNDANCY
+# use --disable-multipart switch with `mc`
+# (to make minio server compute MD5s on entire object instead of chunks)
+disable-multipart=1
 
 [source]
 # source S3 instance (currently only mc client uses)

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -171,12 +171,12 @@ def syncnode(id):
 ### optional: add filename metadata if it exists
 ### TO DO: optionally specify '--disable-multipart' if in config file
     mcCommand=list()
-    mcCommand.append(conf['main']['mcpath'],'--quiet','cp')
+    mcCommand.extend([conf['main']['mcpath'],'--quiet','cp'])
     if 'storageclass' in conf['main']:
-      mcCommand.append('--storage-class',conf['main']['storageclass'])
+      mcCommand.extend(['--storage-class',conf['main']['storageclass']])
     if 'disable_multipart' in conf['main'] and int(conf['main']['disable_multipart'])==1:
       mcCommand.append('--disable-multipart')
-    mcCommand.append(localfile,destPath)
+    mcCommand.extend([localfile,destPath])
     if (debug):
       pprint(mcCommand, stream=sys.stderr)
     result = call(mcCommand)

--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -169,10 +169,14 @@ def syncnode(id):
       destPath="%s/%s/%s/%s/%s/%s"%(conf['destination']['mcendpoint'],conf['destination']['bucket'],id[0:2],id[2:4]
 ,id[4:6],id)
 ### optional: add filename metadata if it exists
-### TO DO: optionally specify '--storage-class REDUCED_REDUNDANCY' if in config file
-    mcCommand=(conf['main']['mcpath'],'--quiet','cp',localfile,destPath)
+### TO DO: optionally specify '--disable-multipart' if in config file
+    mcCommand=list()
+    mcCommand.append(conf['main']['mcpath'],'--quiet','cp')
     if 'storageclass' in conf['main']:
-      mcCommand=(conf['main']['mcpath'],'--quiet','cp','--storage-class',conf['main']['storageclass'],localfile,destPath)
+      mcCommand.append('--storage-class',conf['main']['storageclass'])
+    if 'disable_multipart' in conf['main'] and int(conf['main']['disable_multipart'])==1:
+      mcCommand.append('--disable-multipart')
+    mcCommand.append(localfile,destPath)
     if (debug):
       pprint(mcCommand, stream=sys.stderr)
     result = call(mcCommand)

--- a/syncS3ws.ini
+++ b/syncS3ws.ini
@@ -34,6 +34,9 @@ tmpdir=/mnt/backups/syncS3toS3
 sizelimit=5000000000
 # use nondefault storage class if desired (optional, use S3 server default if omitted)
 # storageclass=REDUCED_REDUNDANCY
+# use --disable-multipart switch with `mc`
+# (to make minio server compute MD5s on entire object instead of chunks)
+# disable-multipart=0
 
 [source]
 # source S3 instance


### PR DESCRIPTION
By default the `mc` client uses multipart uploads.  This causes a remote minio server to calculate the ETag based on the MD5s of each chunk, instead of the entire object, producing an ETag that doesn't match the mongo MD5.  (From what I can tell, minio computes MD5s on each chunk, concatenates them, computes an MD5 on that, then adds -NN to the end where NN is the number of chunks.)

This PR adds an option to add the --disable-multipart switch when using `mc` to cp a large object.