### PR TITLE
Remove botocore vendored

### DIFF
--- a/syncS3toS3.py
+++ b/syncS3toS3.py
@@ -280,12 +280,12 @@ if __name__ == '__main__':
     sslVerifySource = False
     import urllib3
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-    urllib3.disable_warnings(botocore.vendored.requests.packages.urllib3.exceptions.InsecureRequestWarning) 
+#    urllib3.disable_warnings(botocore.vendored.requests.packages.urllib3.exceptions.InsecureRequestWarning) 
   if int(conf['destination']['insecure']) == 1:
     sslVerifyDest = False
     import urllib3
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-    urllib3.disable_warnings(botocore.vendored.requests.packages.urllib3.exceptions.InsecureRequestWarning) 
+#    urllib3.disable_warnings(botocore.vendored.requests.packages.urllib3.exceptions.InsecureRequestWarning) 
 
   readlog(conf['main']['logfile'],done)
   readlog(conf['main']['retryfile'],retry)

--- a/verifyS3.py
+++ b/verifyS3.py
@@ -93,7 +93,7 @@ if ('insecure' in conf['s3'].keys() and int(conf['s3']['insecure']) != 0 ):
     CONFIG_S3_VERIFYCERT = False
     import urllib3
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-    urllib3.disable_warnings(botocore.vendored.requests.packages.urllib3.exceptions.InsecureRequestWarning)
+#    urllib3.disable_warnings(botocore.vendored.requests.packages.urllib3.exceptions.InsecureRequestWarning)
 
 CONFIG_NTHREADS = 1
 if ('nthreads' in conf['main'].keys()):


### PR DESCRIPTION
The botocore.vendored requests library has been removed from the boto library.  Remove our references to them so scripts will run with newer boto libraries.